### PR TITLE
File modified to work fine in ubuntu 18.04

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 toml>=0.10.0
-PyQt5>=5.13.2
+PyQt5>=5.13.2,!=5.14.2,!=5.14.1
 pymunk>=5.6.0
 anytree>=2.8.0
 simpleeval>=0.9.10


### PR DESCRIPTION
Modifying requirements.txt because PyQt5 version 5.14.2 and 5.14.1 fail to install on Ubuntu 18